### PR TITLE
Discarding the master/slave phrasing

### DIFF
--- a/tools/pypack/modulegraph/pkg_resources.py
+++ b/tools/pypack/modulegraph/pkg_resources.py
@@ -2549,7 +2549,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 working_set = WorkingSet()
 try:
     # Does the main program list any requirements?

--- a/usbcreator/backends/udisks/backend.py
+++ b/usbcreator/backends/udisks/backend.py
@@ -144,7 +144,7 @@ class UDisksBackend(Backend):
             status = misc.NEED_FORMAT
         label = get('id-label')
         logging.debug('id-label: %s' % label)
-        parent = get('partition-slave')
+        parent = get('partition-subordinate')
         if fstype == 'vfat' and not get('device-is-mounted'):
             parent_i = self.bus.get_object(DISKS_IFACE, parent)
             parent_i.Get(parent, 'device-file', dbus_interface=PROPS_IFACE)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.